### PR TITLE
SRE-726 Improved Homebrew Formula Debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ brew install <formula>
 
 ## Testing
 
+This project uses [docker compose](https://docs.docker.com/compose/) to create a development environment you can use for testing purposes.
+
+Build the development environments:
+```
+docker-compose build
+```
+
+This creates two services: one with RVM and installed ruby versions, and one without RVM.
+
+Both images have a user `dev.user` that mimics the profile formulae will be installed under. To open a shell as this user, run the following:
+```
+docker-compose run --rm test_with_rvm bash
+```
+
+After this, you should be able to run the following commands.
+
 ### Validation
 To validate that the package will work on your system, install the repository and run the following:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  test_with_rvm:
+    build:
+      context: .
+      dockerfile: ./with_rvm.dockerfile
+    environment:
+      GITHUB_TOKEN: $GITHUB_TOKEN
+    volumes:
+      - ./:/home/dev.user/homebrew-core
+  test_without_rvm:
+    build:
+      context: .
+      dockerfile: ./without_rvm.dockerfile
+    environment:
+      GITHUB_TOKEN: $GITHUB_TOKEN
+    volumes:
+      - ./:/home/dev.user/homebrew-core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: ./with_rvm.dockerfile
     environment:
-      GITHUB_TOKEN: $GITHUB_TOKEN
+      HOMEBREW_GITHUB_API_TOKEN: $GITHUB_TOKEN
     volumes:
       - ./:/home/dev.user/homebrew-core
   test_without_rvm:
@@ -13,6 +13,6 @@ services:
       context: .
       dockerfile: ./without_rvm.dockerfile
     environment:
-      GITHUB_TOKEN: $GITHUB_TOKEN
+      HOMEBREW_GITHUB_API_TOKEN: $GITHUB_TOKEN
     volumes:
       - ./:/home/dev.user/homebrew-core

--- a/with_rvm.dockerfile
+++ b/with_rvm.dockerfile
@@ -1,0 +1,36 @@
+FROM homebrew/brew
+
+ENV USER_NAME dev.user
+ENV USER_HOME /home/${USER_NAME}
+ENV APP_HOME ${USER_HOME}/homebrew-core
+
+# Create groups and a dev user to test with.
+RUN useradd -ms /bin/bash ${USER_NAME} \
+  && usermod -aG sudo ${USER_NAME} \
+  && usermod -aG linuxbrew ${USER_NAME} \
+  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# set up user space
+USER ${USER_NAME}
+RUN mkdir ${APP_HOME}
+WORKDIR ${APP_HOME}
+
+# install RVM gpg key
+RUN sudo apt-get update \
+  && sudo apt-get install -y dirmngr \
+  && gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+
+# install RVM's ordered dependencies and repos
+RUN sudo apt-get install software-properties-common \
+  && sudo apt-add-repository -y ppa:rael-gc/rvm \
+  && sudo apt-get update \
+  && sudo apt-get install -y libfile-fcntllock-perl
+
+# installing RVM as the user causes the installation to behave differently than installing as root
+# install rvm, set the profile, and add to the group
+RUN sudo apt-get install -y rvm \
+  && sudo usermod -aG rvm ${USER_NAME}  \
+  && echo 'source /etc/profile.d/rvm.sh' >> ${USER_HOME}/.bashrc
+
+# install ruby 3.0.0 as default version, and set 2.6.6 as an alternative version
+RUN bash -c ". /etc/profile.d/rvm.sh && rvm install 3.0.0 --default && rvm install 2.6.6"

--- a/without_rvm.dockerfile
+++ b/without_rvm.dockerfile
@@ -1,0 +1,16 @@
+FROM homebrew/brew
+
+ENV USER_NAME dev.user
+ENV USER_HOME /home/${USER_NAME}
+ENV APP_HOME ${USER_HOME}/homebrew-core
+
+# Create groups and a dev user to test with.
+RUN useradd -ms /bin/bash ${USER_NAME} \
+  && usermod -aG sudo ${USER_NAME} \
+  && usermod -aG linuxbrew ${USER_NAME} \
+  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# set up user space
+USER ${USER_NAME}
+RUN mkdir ${APP_HOME}
+WORKDIR ${APP_HOME}


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-726

*NOTE: There is a separate known issue with the current Tinker Homebrew formula. This PR is introducing a way to test and develop formulae without corrupting the developers localhost configuration.*
> Error: Calling GitHub.open_api is disabled! Use GitHub::API.open_rest instead.
> /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:17:in `open_api'

# What

By using `docker-compose`, we can create an isolated container that behaves like an end-user environment when installing formulae and testing their development.

# Why

Currently, developing Homebrew formulae is inconsistent. Differences in local development environments can lead to different results for different users.

# Testing
Clone this repository if you don't have it already, and the checkout the branch:
```
git clone git@github.com:snapsheet/homebrew-core.git
cd homebrew-core
git checkout jSRE_726-improved-homebrew-formula-debu
```

Build the development environments:
```
docker-compose build
```

This creates two services: one with RVM and installed ruby versions, and one without RVM.

Both images have a user `dev.user` that mimics the a user profile that formulae will be installed under. To open a shell as this user, run the following:
```
docker-compose run --rm test_with_rvm bash
```

You should now be able to consistently test and test-install formulae from this repository.
The following command will generate the error described in the known-issue note at the top of this PR description:
```
brew install --debug Formula/tinker.rb

exit # Discard the installed container, and anything that Homebrew installed within it.
```