### PR TITLE
SRE-1055 rvm: command not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,10 @@ RUN sudo apt-get update \
     cmake \
   && curl -sSL https://rvm.io/mpapis.asc | gpg --import -
 
-# install RVM's ordered dependencies and repos
-RUN sudo apt-get install software-properties-common \
-  && sudo apt-add-repository -y ppa:rael-gc/rvm \
-  && sudo apt-get update \
-  && sudo apt-get install -y libfile-fcntllock-perl
+USER dev.user
 
-# installing RVM as the user causes the installation to behave differently than installing as root
-# install rvm, set the profile, and add to the group
-RUN sudo apt-get install -y rvm \
-  && sudo usermod -aG rvm ${USER_NAME}  \
-  && echo 'source /etc/profile.d/rvm.sh' >> ${USER_HOME}/.bashrc
-
-# install ruby 3.0.0 as default version, and set 2.6.6 as an alternative version
-RUN bash -c ". /etc/profile.d/rvm.sh && rvm install 3.0.0 --default && rvm install 2.6.6"
+# Install RVM in user space, as most would.
+RUN bash --login -c "curl -sSL https://get.rvm.io | bash \
+                    && source $HOME/.rvm/scripts/rvm \
+                    && rvm install 3.0.0 --default \
+                    && rvm install 2.6.6"

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -21,6 +21,19 @@ class Tinker < Formula
   license 'MIT'
   version TINKER_VERSION
 
+  # Build dependencies that will be used by RVM.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "coreutils" => :build
+  depends_on "libksba" => :build
+  depends_on "libtool" => :build
+  depends_on "libyaml" => :build
+  depends_on "openssl@1.1" => :build
+  depends_on "pkg-config" => :build
+  depends_on "readline" => :build
+  depends_on "zlib" => :build
+  
+
   # Get the system home directory for the user installing Tinker. Attempting to find the home via
   # +path = `echo $HOME`+ will return the temporary path used while running this formula (same as
   # returned by the +pwd+ method).

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -3,12 +3,17 @@
 # Resources: https://github.com/sportngin/brew-gem
 
 require_relative '../lib/ruby_gems_download_strategy'
+require_relative '../lib/ruby_manager'
+require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
 TINKER_VERSION = '0.2.1'.freeze
 
 class Tinker < Formula
+  include RubyManager
+  include DebugTools
+
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
@@ -16,88 +21,110 @@ class Tinker < Formula
   license 'MIT'
   version TINKER_VERSION
 
-  def setup_debug_tools
-    Homebrew.install_gem_setup_path! 'pry'
-    Homebrew.install_gem_setup_path! 'pry-byebug', executable: 'pry'
-    require 'pry-byebug'
+  # Get the system home directory for the user installing Tinker. Attempting to find the home via
+  # +path = `echo $HOME`+ will return the temporary path used while running this formula (same as
+  # returned by the +pwd+ method).
+  #
+  # @return [String] Path to the +$HOME+ of the user running the formula.
+  def user_home
+    @user_home ||= `eval echo ~$USER`.strip
   end
 
-  def install
-    if Context.current.debug?
-      setup_debug_tools
-      @tap = CoreTap.instance unless tap?
-    end
+  # Version of Ruby required to run Tinker. This is required for using the {RubyManager}.
+  #
+  # @return [String] Semantic version of Ruby runtime (+3.0.1+, etc).
+  def ruby_version
+    @ruby_version ||= metadata.required_ruby_version.to_s.split.last
+  end
 
-    # set GEM_HOME and GEM_PATH to make sure we package all the dependent gems
-    # together without accidently picking up other gems on the gem path since
-    # they might not be there if, say, we change to a different rvm gemset
-    ENV['GEM_HOME'] = prefix.to_s
-    ENV['GEM_PATH'] = prefix.to_s
+  # Metadata associated with the Tinker gem. Used to get dependencies, requirements, etc.
+  #
+  # @return [Object] Reference to metadata object loaded from a gem.
+  def metadata
+    @metadata ||= YAML.load(`tar -xOf #{tinker_gem_path} metadata.gz | gzip -dc`)
+  end
 
-    # Use /usr/local/bin at the front of the path instead of Homebrew shims,
-    # which mess with Ruby's own compiler config when building native extensions
-    ENV['PATH'] = ENV['PATH'].sub(HOMEBREW_SHIMS_PATH.to_s, '/usr/local/bin') if defined?(HOMEBREW_SHIMS_PATH)
+  # Find the path of the gem that will be installed by this formula.
+  #
+  # @return [String] Cached path to the installed gem.
+  def tinker_gem_path
+    @tinker_gem_path ||= HOMEBREW_CACHE.cd { "#{pwd}/#{name}-#{version}.gem" }
+  end
 
-    metadata = YAML.load(`tar -xOf #{name}-#{version}.gem metadata.gz | gzip -dc`)
-    ruby_version = metadata.required_ruby_version.to_s.split.last
-    ruby_bin = ''
+  def tinker_env_vars
+    ruby_environment.merge(
+      'PATH' => "#{ruby_environment['PATH']}:\#{ENV['PATH']}",
+      'TINKER_ENV' => 'production'
+    )
+  end
 
+  # Get the path to installed gems so we can include them in the Tinker runtime before execution.
+  #
+  # @return [Array] List of paths to the +lib+ directories of installed gem dependencies.
+  def installed_gem_lib_paths
+    ruby_lib_paths = Dir.glob("#{gem_path}/gems/*/lib")
+    # Need to fix the path for concurrent-ruby.
+    ccrb = ruby_lib_paths.select { |path| path.include?('concurrent-ruby') }.first
+    ruby_lib_paths.select { |path| !path.include?('concurrent-ruby') } + ["#{ccrb}/concurrent-ruby"]
+  end
+
+  # Use the methods in the {RubyManager} to create an environment for installing gems specifically
+  # for use with this formula.
+  def install_tinker_gem
     RubyGemsDownloadStrategy.gem_config_file do |_config_path|
       HOMEBREW_CACHE.cd do
-        install_cmd = [
-          'gem', 'install', cached_download,
-          '--no-document',
-          '--no-wrapper',
-          '--no-user-install',
-          '--install-dir', prefix,
-          '--bindir', bin
-        ]
-
-        `bash --login -c 'rvm install #{ruby_version}'`
-        `bash --login -c 'rvm use #{ruby_version} && #{install_cmd.join(' ')}'`
-        ruby_bin = `bash --login -c 'rvm use #{ruby_version} > /dev/null && which ruby'`.strip
+        with_env(ruby_environment) do
+          system('gem', 'install', cached_download)
+        end
       end
+
+      raise "gem install #{name} failed with status #{$?.exitstatus}" unless $?.success?
     end
+  end
 
-    raise "gem install #{name} failed with status #{$?.exitstatus}" unless $?.success?
-
-    bin.rmtree if bin.exist?
-    bin.mkpath
-
-    brew_gem_prefix = prefix + "gems/#{name}-#{version}"
-
-    completion_for_bash = Dir[
-      "#{brew_gem_prefix}/completion{s,}/#{name}.{bash,sh}",
-      "#{brew_gem_prefix}/**/#{name}{_,-}completion{s,}.{bash,sh}"
-    ].first
-
-    bash_completion.install completion_for_bash if completion_for_bash
-
-    completion_for_zsh = Dir[
-      "#{brew_gem_prefix}/completions/#{name}.zsh",
-      "#{brew_gem_prefix}/**/#{name}{_,-}completion{s,}.zsh"
-    ].first
-
-    zsh_completion.install completion_for_zsh if completion_for_zsh
-
-    ruby_libs = Dir.glob("#{prefix}/gems/*/lib")
-
+  # Create the binary executable entry points for all executables included with the Tinker gem.
+  def create_bin_entrypoints
     metadata.executables.each do |exe|
-      file = Pathname.new("#{brew_gem_prefix}/#{metadata.bindir}/#{exe}")
+      file = Pathname.new("#{gem_path}/#{metadata.bindir}/#{exe}")
       (bin + file.basename).open('w') do |f|
         f << <<~RUBY
-          #!#{ruby_bin} --disable-gems
-          ENV['GEM_HOME']="#{prefix}"
-          ENV['GEM_PATH']="#{prefix}"
+          #!#{ruby_path}/bin/ruby --disable-gems
+          #{tinker_env_vars.map { |k, v| "ENV['#{k}'] = \"#{v}\"" }.join("\n")}
           require 'rubygems'
-          $:.unshift(#{ruby_libs.map(&:inspect).join(',')})
+          $:.unshift(#{installed_gem_lib_paths.map(&:inspect).join(',')})
           load "#{file}"
         RUBY
       end
     end
   end
 
+  def install
+    setup_debug_tools if Context.current.debug?
+
+    bin.rmtree if bin.exist?
+    bin.mkpath
+
+    log_path = if OS.mac?
+      "#{user_home}/Library/Logs/Homebrew/tinker"
+    elsif OS.linux?
+      "#{user_home}/.cache/Homebrew/Logs/tinker"
+    end
+
+    ohai("Installing dedicated version of Ruby #{ruby_version}. This will take several minutes.")
+    ohai("For detailed progress information, run the following in a new CLI:")
+    ohai("  tail -f #{log_path}/01.rvm")
+    install_ruby
+
+    ohai("Installing ruby gem for #{name} #{version}.")
+    ohai("For detailed progress information, run the following in a new CLI:")
+    ohai("  tail -f #{log_path}/02.gem")
+    install_tinker_gem
+
+    ohai('Creating Tinker bin entrypoints.')
+    create_bin_entrypoints
+  end
+
   test do
-    assert_match TINKER_VERSION, shell_output("TINKER_ENV=production tinker --version")
+    assert_match TINKER_VERSION, shell_output("tinker --version")
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Snapsheet Core Homebrew Tap
 This is a Homebrew tap for useful formulae used by engineers at Snapsheet.
 
+* [Explanation of how Homebrew works](https://www.quora.com/How-does-Homebrew-work-internally?share=1)
+
 ## Installation
 These packages require a GitHub token to be set up in your environment with the name `HOMEBREW_GITHUB_API_TOKEN`.
 

--- a/lib/debug_tools.rb
+++ b/lib/debug_tools.rb
@@ -1,0 +1,7 @@
+module DebugTools
+  def setup_debug_tools
+    Homebrew.install_gem_setup_path! 'pry-byebug', executable: 'pry'
+    Homebrew.install_gem_setup_path! 'pry-rescue', executable: 'pry'
+    require 'pry-byebug'
+  end
+end

--- a/lib/ruby_gems_download_strategy.rb
+++ b/lib/ruby_gems_download_strategy.rb
@@ -41,10 +41,10 @@ class RubyGemsDownloadStrategy < AbstractDownloadStrategy
   end
 
   def run_as_user(command_string)
-    system(*bash_cmd(command_string))
+    system(*shell_cmd(command_string))
   end
 
-  def bash_cmd(command_string)
+  def shell_cmd(command_string)
     [ENV['SHELL'], '--login', '-c', command_string]
   end
 

--- a/lib/ruby_gems_download_strategy.rb
+++ b/lib/ruby_gems_download_strategy.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require_relative './debug_tools'
+
 require 'yaml'
 require 'download_strategy'
 
 class RubyGemsDownloadStrategy < AbstractDownloadStrategy
+  include DebugTools
+
   class << self
     def gem_config
       {
@@ -36,21 +40,22 @@ class RubyGemsDownloadStrategy < AbstractDownloadStrategy
     cached_location.unlink if cached_location.exist?
   end
 
-  def setup_debug_tools
-    Homebrew.install_gem_setup_path! 'pry'
-    Homebrew.install_gem_setup_path! 'pry-byebug', executable: 'pry'
-    require 'pry-byebug'
+  def run_as_user(command_string)
+    system(*bash_cmd(command_string))
+  end
+
+  def bash_cmd(command_string)
+    [ENV['SHELL'], '--login', '-c', command_string]
   end
 
   def fetch
-    Homebrew.setup_gem_environment!
-    ohai "Fetching #{name} from gem source"
+    ohai("Fetching #{name} gem from GitHub packages.")
     setup_debug_tools if Context.current.debug?
 
     clear_cache
     RubyGemsDownloadStrategy.gem_config_file do |config_path|
       HOMEBREW_CACHE.cd do
-        system('gem', 'fetch', name, '--version', version, '--config-file', config_path)
+        run_as_user("gem fetch #{name} --version #{version} --config-file #{config_path}")
       end
     end
   end

--- a/lib/ruby_manager.rb
+++ b/lib/ruby_manager.rb
@@ -1,0 +1,153 @@
+# Module for managing Ruby installations and versions. This module will install an independent
+# version of Ruby for every formula that uses it. This ensures that any applications that depend on
+# specific Ruby versions won't have those dependencies broke by untracked changes on the system.
+#
+# Currently uses RVM for the build and installation process.
+#
+# = Usage
+#  class Tinker < Formula
+#    include RubyManager
+#    
+#    # REQUIRED, as +user_home+ will be called from the +RubyManager+ module.
+#    def user_home
+#      @user_home ||= `eval echo ~$USER`.strip
+#    end
+#    
+#    # REQUIRED, as +ruby_version+ will be called from the +RubyManager+ module.
+#    def ruby_version
+#      '3.0.1'
+#    end
+#    
+#    def install
+#      install_ruby
+#    end
+#
+# Also, see this discussion between the RVM and Homebrew maintainers about integrations between the
+# projects:
+#   https://github.com/rvm/rvm/issues/1623
+module RubyManager
+  # Destination path for cloned copy installation of RVM dedicated for this formula.
+  #
+  # @return [String] Path to the directory containing the RVM installation.
+  def rvm_path
+    "#{prefix}/.rvm"
+  end
+
+  # Directory for the dedicated installation of the Ruby runtime.
+  #
+  # @return [String] Path to the directory containing the Ruby runtime code.
+  def ruby_path
+    "#{rvm_path}/rubies/ruby-#{ruby_version}"
+  end
+
+  # Directory for the gems associated with the dedicated installation of the Ruby runtime.
+  #
+  # @return [String] Path to the directory containing gems for the dedicated Ruby installation.
+  def gem_path
+    "#{rvm_path}/gems/ruby-#{ruby_version}"
+  end
+
+  # Clone an existing RVM runtime installation to the formula prefix directory. This is required to
+  # build and install dedicated versions of Ruby for the formula.
+  #
+  # @param [String] source_rvm_path Path to the existing RVM runtime installation.
+  # @param [String] destination_rvm_path Path that will be created with a duplicate version of RVM.
+  def clone_rvm_directory(source_rvm_path, destination_rvm_path)
+    mkdir_names = [
+      'archives',
+      'environments',
+      'gems',
+      'log',
+      'rubies',
+      'src',
+      'tmp',
+      'user',
+      'wrappers'
+    ]
+
+    link_names = Dir["#{source_rvm_path}/*"]
+      .map { |path| path.split('/').last }
+      .select { |path| mkdir_names.exclude?(path) }
+
+    mkdir(destination_rvm_path)
+
+    link_names.each do |name|
+      ln_s("#{source_rvm_path}/#{name}", "#{destination_rvm_path}/#{name}")
+    end
+
+    mkdir_names.each { |name| mkdir("#{destination_rvm_path}/#{name}") }
+  end
+
+  # List the parts of the +$PATH+ that are not shimmed by Homebrew. This is used to avoid build issues
+  # where Homebrew-dependencies collide with system-dependencies.
+  #
+  # @return [Array] An array of Strings representing paths to include in +$PATH+.
+  def non_shim_paths
+    ENV['PATH'].split(':').select { |path| path.exclude?(HOMEBREW_SHIMS_PATH.to_s) }
+  end
+
+  # List the parts of the $PATH+ that are not associated with an installation of Homebrew. This is
+  # used to prevent Homebrew operation commands from colliding with application runtime commands.
+  #
+  # @return [Array] An array of Strings representing paths to include in +$PATH+.
+  def non_homebrew_paths
+    ENV['PATH'].split(':').select { |path| path.exclude?('Homebrew') }
+  end
+
+  # Install the required Ruby version into an isolated directory using RVM.
+  #
+  # When dependencies are not found, RVM attempts to use Homebrew to install them. This will raise
+  # an error, because we are already executing RVM from within the context of a Homebrew formula.
+  # To prevent this, we set +autolibs+ to +read-fail+, which will cause RVM to fail if dependencies
+  # are not found.
+  #
+  # We set the +with-gcc+ explicitly to +gcc+ so that it won't attempt to build Ruby with the clang
+  # compiler (found on macos).
+  #
+  # The +--verbose+ and +--debug+ flags are set so we will see detailed logs if an installation
+  # fails for whatever reason.
+  #
+  # @see https://github.com/rvm/rvm/blob/35e894c7070eaabc38d91220f6e26d1585a7098a/help/autolibs.md
+  # @see https://github.com/rvm/rvm/issues/1623#issuecomment-14181568
+  def install_ruby
+    clone_rvm_directory("#{user_home}/.rvm", rvm_path)
+
+    with_env(
+      rvm_path: rvm_path,
+      PATH: non_shim_paths.join(':')
+    ) do
+      system(
+        "#{rvm_path}/bin/rvm",
+        '--autolibs=read-fail',
+        '--with-gcc=gcc',
+        '--verbose', '--debug',
+        'install', ruby_version
+      )
+    end
+  end
+
+  # Get environment variables for executing bin files from the isolated version of Ruby. This is
+  # used for building and installing gems. Use this with the +with_env+ Homebrew method to run
+  # +system+ commands.
+  #
+  # = Usage
+  #  with_env(ruby_environment) do
+  #    system('gem', 'install', 'mygem.gem')
+  #  end
+  #
+  # @see https://rubydoc.brew.sh/Kernel.html#with_env-instance_method
+  #
+  # @return [Hash] A Hash of environment variables used for executing commands.
+  def ruby_environment
+    ordered_paths = ["#{ruby_path}/bin", '/usr/local/bin'] + non_homebrew_paths
+
+    @ruby_environment ||= {
+        'PATH' => ordered_paths.join(':'),
+        'GEM_HOME' => gem_path,
+        'GEM_PATH' => gem_path,
+        'MY_RUBY_HOME' => ruby_path,
+        'IRBRC' => "#{ruby_path}/.irbrc",
+        'RUBY_VERSION' => "ruby-#{ruby_version}"
+      }
+  end
+end


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1055

Builds were passing when we tested them via docker compose using Linux, but the process that was used for installation on Linux did not align properly with MacOS. This fixes installations for both operating systems by creating an isolated version of Ruby that won't overlap with any existing installation of Ruby. It uses RVM to achieve this (see code documentation comments).

### `DebugTools`
A new module that can be shared between formulas and download strategies for enabling `binding.pry` breakpoints when attempting to install a formula with `--debug`.

### `RubyManager`
This manages the building and installation of a dedicated version of Ruby using RVM. This requires that the user has RVM installed, and that RVM is installed using the single-user method, which is recommended in their documentation. Because of this, I have modified the Dockerfile so the Linux container will also install RVM in user space.

### `RubyGemsDownloadStrategy`
This module was using the Homebrew-native version of Ruby to download the gem, which could cause issues if/when Homebrew makes changes to this the next time a user does a `brew update && brew upgrade`. By using the $SHELL of the user's environment, the version of `gem` used will be from the user's environment.

### `Tinker`
This as been refactored to reflect the changes above.

### Testing Linux

Checkout this branch and build the docker image for development.
```
docker compose build
```

**Known Issue**: Attempting to run the installer in Linux more than once within the same container will show an error. This can be resolved terminating the container and starting a new one. This does not occur on MacOS.

Attempt to install Tinker on the docker image by starting a container:
```
docker compose run --rm cli
```

Within the container, try the installer with the `--debug` option, and confirm Tinker was installed:
```
brew install --debug --build-from-source Formula/tinker.rb
tinker --version
```

Stop the container and start a new one. Then confirm you can install without the `--debug` option:
```
brew install --build-from-source Formula/tinker.rb
tinker --version
```

### Testing MacOS

Checkout this branch and make sure you don't have tinker already installed:
```
brew remove tinker
```

Install Tinker with the `--debug` flag. This assumes that you have `GITHUB_TOKEN` set on your environment. This will take about 9min...
```
HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN brew install --debug --build-from-source Formula/tinker.rb
tinker --version
```

Remove Tinker and confirm that you can install without the `--debug` flag, as most users will. This will also take about 9min...
```
HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN brew install --build-from-source Formula/tinker.rb
tinker --version
```