### PR TITLE
SRE-1080 Error: cannot load such file -- interception

### DIFF
--- a/lib/debug_tools.rb
+++ b/lib/debug_tools.rb
@@ -2,6 +2,5 @@ module DebugTools
   def setup_debug_tools
     Homebrew.install_gem_setup_path! 'pry-byebug', executable: 'pry'
     Homebrew.install_gem_setup_path! 'pry-rescue', executable: 'pry'
-    require 'pry-byebug'
   end
 end


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1080

## What
Fixes issue when installing tinker homebrew formula using --debug.

## Why
This gets rid of the error seen on docker contain and the 11.6.2 specific macOS version

## How
Removes the specific line in the `setup_debug_tools` method that causes the issue.

## Testing
### Reproduce Issue
First reproduce the error on the `main` branch of this project by running the following:
```
docker compose build
docker compose run --rm cli
brew install --debug --build-from-source Formula/tinker.rb
brew remove tinker
brew install --debug --build-from-source Formula/tinker.rb
```
The install will fail during the second install.

### Test solution
Now pull down these changes and run the following.

Build and start the docker container
```
docker compose build
docker compose run --rm cli
```
Then download the Tinker homebrew formula, and confirm the Tinker version
```
brew install --debug --build-from-source Formula/tinker.rb
tinker --version
```
After confirming the tinker version, remove the tinker homebrew formula and then re-install it:
```
brew remove tinker
brew install --debug --build-from-source Formula/tinker.rb
tinker --version
```
There should be no issues 

