### PR TITLE
SRE-1117 Error: Default profile needs to be set

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -33,6 +33,8 @@ class Tinker < Formula
   depends_on "readline" => :build
   depends_on "zlib" => :build
   
+  # Runtime dependencies that will be used by Tinker.
+  depends_on "awscli" => "2"
 
   # Get the system home directory for the user installing Tinker. Attempting to find the home via
   # +path = `echo $HOME`+ will return the temporary path used while running this formula (same as

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       HOMEBREW_GITHUB_API_TOKEN: $GITHUB_TOKEN
     volumes:
       - ./:/home/dev.user/homebrew-core
+      - ~/.aws:/home/dev.user/.aws


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1117

This addresses a dependency issue that occurs when the local version of awscli conflicts with the version of awscli that Tinker depends upon.

We specify `awscli` version 2 as a [Homebrew dependency](https://docs.brew.sh/Formula-Cookbook#specifying-other-formulae-as-dependencies). When installed, Homebrew will explicitly include the library in the PATH that we write within the wrapper entrypoint for Tinker. This ensures the brew-installed version will take priority, without requiring the user to modify their PATH via .profile/.bashrc/.zshrc/etc.

# Testing

## Linux
Checkout this branch, rebuild the dev image, and start a container. This will mount the `~/.aws` directory and enable you to test `tinker auth`.
```
git checkout jSRE_1117-error-default-profile-needs-to
docker compose build
docker compose run --rm cli

sudo apt-add-repository universe && sudo apt update
sudo apt install -y python2-minimal
sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1

python --version

curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py
sudo python2 /tmp/get-pip.py
# verify pip uses python 2.7
pip --version

sudo apt-get install -y libyaml-dev libpython2.7-dev
pip install awscli==1.16.75

source ~/.profile
aws --version # should be "aws-cli/1.16.75"
brew install awscli
source ~/.profile
aws --version # should still be "aws-cli/1.16.75"
brew install --build-from-source Formula/tinker.rb
tinker auth # worked correctly and requested MFA
brew uninstall tinker

git checkout main
brew install --build-from-source Formula/tinker.rb
tinker auth # did not request MFA and printed `Tinker -- Default profile needs to be set`
source ~/.profile
aws --version # should still be "aws-cli/1.16.75"
```

Attempt to uninstall awscli and verify that Homebrew will raise a dependency error:
```
brew remove awscli
```
```
Error: Refusing to uninstall /usr/local/Cellar/awscli/2.4.18
because it is required by tinker, which is currently installed.
```

## MacOS
```
git checkout jSRE_1117-error-default-profile-needs-to

# verify python 2.7 is default
python --version

# verify pip uses python 2.7
pip --version

aws --version # should be "aws-cli/1.16.75"
brew install awscli
aws --version # should still be "aws-cli/1.16.75"

brew install --build-from-source Formula/tinker.rb
tinker auth # worked correctly and requested MFA
brew uninstall tinker

git checkout main
brew install --build-from-source Formula/tinker.rb
tinker auth # did not request MFA and printed `Tinker -- Default profile needs to be set`

aws --version # should still be "aws-cli/1.16.75"
```

Attempt to uninstall awscli and verify that Homebrew will raise a dependency error:
```
brew remove awscli
```
```
Error: Refusing to uninstall /usr/local/Cellar/awscli/2.4.18
because it is required by tinker, which is currently installed.
```

## Cleanup

Uninstall the dev version of the formula from your host.
```
brew remove tinker
```