### PR TITLE
SRE-1147 Create Session Manager Plugin Formula

### DIFF
--- a/Formula/session-manager-plugin.rb
+++ b/Formula/session-manager-plugin.rb
@@ -23,7 +23,27 @@ class SessionManagerPlugin < Formula
     regex(%r{<td>\s*v?(\d+(?:\.\d+)+)\s*</td>}i)
   end
 
+  def plugin_path
+    '/usr/local/sessionmanagerplugin'
+  end
+
+  def symlink_path
+    '/usr/local/bin/session-manager-plugin'
+  end
+
+  def fail_if_already_installed
+    if Dir.exist?(self.plugin_path) || File.exist?(self.symlink_path)
+      error_message = [
+        "Existing installation found in #{self.plugin_path}. Run the following and try the installation again:",
+        "  sudo rm -rf #{self.plugin_path} #{self.symlink_path}"
+      ]
+      odie(error_message.join("\n"))
+    end
+  end
+
   def install
+    self.fail_if_already_installed
+
     on_macos do
       system 'tar', 'xvf', 'session-manager-plugin.pkg'
       system 'tar', 'xvf', 'Payload'
@@ -35,6 +55,6 @@ class SessionManagerPlugin < Formula
       system 'tar', 'xvf', 'data.tar.gz'
     end
 
-    prefix.install Dir['./usr/local/sessionmanagerplugin/*']
+    prefix.install Dir[".#{self.plugin_path}/*"]
   end
 end

--- a/Formula/session-manager-plugin.rb
+++ b/Formula/session-manager-plugin.rb
@@ -1,5 +1,6 @@
 # A clone of https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/session-manager-plugin.rb
-# implemented here so it can be used as a dependency.
+# implemented here so it can be used as a dependency for other Formulae.
+# This formula only installs the client.
 class SessionManagerPlugin < Formula
   version '1.2.295.0'
   desc 'Plugin for AWS CLI to start and end sessions that connect to managed instances'

--- a/Formula/session-manager-plugin.rb
+++ b/Formula/session-manager-plugin.rb
@@ -1,8 +1,9 @@
 # A clone of https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/session-manager-plugin.rb
 # implemented here so it can be used as a dependency for other Formulae.
 # This formula only installs the client.
+SESSION_MANAGER_PLUGIN_VERSION = '1.2.295.0'
 class SessionManagerPlugin < Formula
-  version '1.2.295.0'
+  version SESSION_MANAGER_PLUGIN_VERSION
   desc 'Plugin for AWS CLI to start and end sessions that connect to managed instances'
   homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
 
@@ -56,5 +57,9 @@ class SessionManagerPlugin < Formula
     end
 
     prefix.install Dir[".#{self.plugin_path}/*"]
+  end
+
+  test do
+    assert_match SESSION_MANAGER_PLUGIN_VERSION, shell_output('session-manager-plugin --version').strip
   end
 end

--- a/Formula/session_manager_plugin.rb
+++ b/Formula/session_manager_plugin.rb
@@ -1,0 +1,26 @@
+# A clone of https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/session-manager-plugin.rb
+# implemented here so it can be used as a dependency.
+class SessionManagerPlugin < Formula
+  version '1.2.295.0'
+  desc 'Plugin for AWS CLI to start and end sessions that connect to managed instances'
+  homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
+
+  on_macos do
+    sha256 '67e527dd19b2ae6d5b5de62c75aedb4241f31b2ae177be3e118db8b4d067ad26'
+    url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/session-manager-plugin.pkg",
+        verified: 's3.amazonaws.com/session-manager-downloads/'
+  end
+
+  livecheck do
+    url :homepage
+    regex(%r{<td>\s*v?(\d+(?:\.\d+)+)\s*</td>}i)
+  end
+
+  def install
+    on_macos do
+      system 'tar', 'xvf', 'session-manager-plugin.pkg'
+      system 'tar', 'xvf', 'Payload'
+      prefix.install Dir['./usr/local/sessionmanagerplugin/*']
+    end
+  end
+end

--- a/Formula/session_manager_plugin.rb
+++ b/Formula/session_manager_plugin.rb
@@ -11,6 +11,12 @@ class SessionManagerPlugin < Formula
         verified: 's3.amazonaws.com/session-manager-downloads/'
   end
 
+  on_linux do
+    sha256 '12bcbec7d394275c2085d610fdbd53171c9083b3abf332d90baf3bcc3e730d2c'
+    url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_64bit/session-manager-plugin.deb",
+        verified: 's3.amazonaws.com/session-manager-downloads/'
+  end
+
   livecheck do
     url :homepage
     regex(%r{<td>\s*v?(\d+(?:\.\d+)+)\s*</td>}i)
@@ -20,7 +26,14 @@ class SessionManagerPlugin < Formula
     on_macos do
       system 'tar', 'xvf', 'session-manager-plugin.pkg'
       system 'tar', 'xvf', 'Payload'
-      prefix.install Dir['./usr/local/sessionmanagerplugin/*']
     end
+
+    on_linux do
+      system 'ar', 'vx', 'session-manager-plugin.deb'
+      system 'tar', 'xvf', 'control.tar.gz'
+      system 'tar', 'xvf', 'data.tar.gz'
+    end
+
+    prefix.install Dir['./usr/local/sessionmanagerplugin/*']
   end
 end


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1147

This introduces a new formula for installing the `session-manager-plugin` for both Linux and macOS. This will be included as a dependency of the Tinker formula in a follow-up change.

# Testing

Checkout this branch:
```shell
git checkout jSRE_1147-update-homebrew-formula-depend
```

## Test with macOS

Make sure you don't have the Cask version installed.
```shell
brew remove session-manager-plugin
```

Install the commands.
```shell
brew install awscli jq
brew install --build-from-source Formula/session-manager-plugin.rb
```

Verify the brew test works.
```shell
brew test session-manager-plugin
```

Verify which version 
```shell
# for macOS it should be /usr/local/bin/session-manager-plugin
which session-manager-plugin

# should be 1.2.295.0
session-manager-plugin --version
```

Comment out this line in your .profile/.bashrc/.zshrc file.
Open a new CLI window
Renable the line in your .profile/.bashrc/.zshrc file.
```shell
PATH="${HOME}/Workspace/git-scripts:${PATH}"
```
Use this window to run the below commands so that your PATH doesn't include the version of `session-manager-plugin` bundled with git-scripts.

We can use the full path to the new version of awscli for testing: `/usr/local/bin/aws`

Start a new task and then connect with ECS Exec.
```shell
NEW_TASK=$(/usr/local/bin/aws ecs --profile user_session --region us-east-2 run-task \
  --cluster awseb-fc51-deploy-testing-mrf8npvmdm \
  --group authenticator \
  --enable-execute-command \
  --count 1 \
  --launch-type FARGATE \
  --task-definition awseb-fc51-deploy-testing-mrf8npvmdm-remote_session \
  --network-configuration 'awsvpcConfiguration={subnets=["subnet-09f2561f8b19ed301"]}')

echo $NEW_TASK | jq # to see what was created
```

Start a remote session using the installed plugin.
```shell
/usr/local/bin/aws ecs --profile user_session --region us-east-2 execute-command \
  --cluster awseb-fc51-deploy-testing-mrf8npvmdm \
  --task $(echo $NEW_TASK | jq -r '.tasks[0].taskArn') \
  --container remote_session \
  --interactive \
  --command /bin/bash
```

Run some commands to verify you're in an environment container:
```shell
The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.


Starting session with SessionId: ecs-execute-command-0e6e0af5ba1c7f022
root@ip-101-1-69-107:/app# rails c
Loading qa environment (Rails 5.2.5)
irb(main):001:0> User.count
D, [2022-03-18T20:17:57.410496 #336] DEBUG -- :    (1.4ms)  SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
D, [2022-03-18T20:17:57.416535 #336] DEBUG -- :    (1.3ms)  SELECT COUNT(*) FROM `users`
=> 144
irb(main):002:0> exit
root@ip-101-1-69-107:/app# exit
exit


Exiting session with sessionId: ecs-execute-command-0e6e0af5ba1c7f022.
```

Stop the task so it won't run forever.
```shell
/usr/local/bin/aws ecs --profile user_session --region us-east-2 stop-task \
  --cluster awseb-fc51-deploy-testing-mrf8npvmdm \
  --task $(echo $NEW_TASK | jq -r '.tasks[0].taskArn')
```

Remove the plugin so you can later verify it works as dependency.
```shell
brew remove session-manager-plugin
```

## Test with Linux
Open a new docker container for testing:
```shell
docker compose run --rm cli
```

Install the commands.
```shell
brew install awscli jq
brew install --build-from-source Formula/session-manager-plugin.rb
```

Verify the brew test works.
```shell
brew test session-manager-plugin
```

Verify which version 
```shell
# for Linux it should be /home/linuxbrew/.linuxbrew/bin/session-manager-plugin
which session-manager-plugin

# should be 1.2.295.0
session-manager-plugin --version
```

Start a new task and then connect with ECS Exec.
```shell
NEW_TASK=$(aws ecs --profile user_session --region us-east-2 run-task \
  --cluster awseb-fc51-deploy-testing-mrf8npvmdm \
  --group authenticator \
  --enable-execute-command \
  --count 1 \
  --launch-type FARGATE \
  --task-definition awseb-fc51-deploy-testing-mrf8npvmdm-remote_session \
  --network-configuration 'awsvpcConfiguration={subnets=["subnet-09f2561f8b19ed301"]}')

echo $NEW_TASK | jq # to see what was created
```

Start a remote session using the installed plugin.
```shell
aws ecs --profile user_session --region us-east-2 execute-command \
  --cluster awseb-fc51-deploy-testing-mrf8npvmdm \
  --task $(echo $NEW_TASK | jq -r '.tasks[0].taskArn') \
  --container remote_session \
  --interactive \
  --command /bin/bash
```

Run some commands to verify you're in an environment container:
```shell
The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.


Starting session with SessionId: ecs-execute-command-0e6e0af5ba1c7f022
root@ip-101-1-69-107:/app# rails c
Loading qa environment (Rails 5.2.5)
irb(main):001:0> User.count
D, [2022-03-18T20:17:57.410496 #336] DEBUG -- :    (1.4ms)  SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
D, [2022-03-18T20:17:57.416535 #336] DEBUG -- :    (1.3ms)  SELECT COUNT(*) FROM `users`
=> 144
irb(main):002:0> exit
root@ip-101-1-69-107:/app# exit
exit


Exiting session with sessionId: ecs-execute-command-0e6e0af5ba1c7f022.
```

Stop the task so it won't run forever.
```shell
aws ecs --profile user_session --region us-east-2 stop-task \
  --cluster awseb-fc51-deploy-testing-mrf8npvmdm \
  --task $(echo $NEW_TASK | jq -r '.tasks[0].taskArn')
```