### PR TITLE
SRE-1169 Include Session Manager Plugin Dependency in Tinker Formula

### DIFF
--- a/Formula/session-manager-plugin.rb
+++ b/Formula/session-manager-plugin.rb
@@ -8,7 +8,7 @@ class SessionManagerPlugin < Formula
   homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
 
   on_macos do
-    sha256 '67e527dd19b2ae6d5b5de62c75aedb4241f31b2ae177be3e118db8b4d067ad26'
+    sha256 'dad3eb15607c675d20ddc8a4b199c46d458b70ed6188afb7c83fb1a1d7a44911'
     url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/session-manager-plugin.pkg",
         verified: 's3.amazonaws.com/session-manager-downloads/'
   end

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -35,6 +35,7 @@ class Tinker < Formula
   
   # Runtime dependencies that will be used by Tinker.
   depends_on "awscli" => "2"
+  depends_on "snapsheet/core/session-manager-plugin" => "1.2.295"
 
   # Get the system home directory for the user installing Tinker. Attempting to find the home via
   # +path = `echo $HOME`+ will return the temporary path used while running this formula (same as


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1169

This includes the recently published session-manager-plugin formula as a dependency in the Tinker Homebrew formula.

While testing, I discovered that the SHA has changed for macos version of the plugin.
```shell
Error: tinker: SHA256 mismatch
Expected: 67e527dd19b2ae6d5b5de62c75aedb4241f31b2ae177be3e118db8b4d067ad26
  Actual: dad3eb15607c675d20ddc8a4b199c46d458b70ed6188afb7c83fb1a1d7a44911
    File: /Users/david.tittle/Library/Caches/Homebrew/downloads/456d9d21168cf84a91f8ac096612ada4ed42c61c569a92a2516ce0281c06dfa2--session-manager-plugin.pkg
```

This only occurred while testing the installation on macOS.

### Testing on Linux
Checkout this branch, start a container, and run the installer:
```shell
➜  homebrew-core git:(main) git checkout jSRE_1169-include-session-manager-plugin
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) docker compose run --rm cli
# ...within container...
dev.user@85817af64483:~/homebrew-core$ brew install --build-from-source Formula/tinker.rb
```

This will take several minutes. Eventually you will see that both Tinker and the session-manager-plugin have been installed.
```shell
dev.user@85817af64483:~/homebrew-core$ tinker --version
0.2.1

dev.user@85817af64483:~/homebrew-core$ session-manager-plugin --version
1.2.295.0
```

### Testing on macOS
Remove any existing versions so they don't interfere with testing:
```shell
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) brew remove tinker session-manager-plugin

# you can also run this first so it won't be grouped with the installation CLI output
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) brew update
```

Because of the SHA difference, you will need to first install the session-manager-plugin from formula reference:
```shell
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) brew install --build-from-source Formula/session-manager-plugin.rb
```

Assuming you have a github token in $GITHUB_TOKEN, pass this while running the installer for tinker:
```shell
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN brew install --build-from-source Formula/tinker.rb
```

This will take several minutes. After this completes, confirm the proper versions of both are installed:
```shell
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) tinker --version
0.2.1
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) /usr/local/bin/session-manager-plugin --version
1.2.295.0
```

Uninstall them.
```shell
➜  homebrew-core git:(jSRE_1169-include-session-manager-plugin) brew remove tinker session-manager-plugin
Warning: Treating session-manager-plugin as a formula. For the cask, use homebrew/cask/session-manager-plugin
Uninstalling /usr/local/Cellar/tinker/0.2.1... (32,457 files, 287MB)
Uninstalling /usr/local/Cellar/session-manager-plugin/1.2.295.0... (9 files, 11MB)
```