### PR TITLE
SRE-1201 Update Homebrew Formula for Release 0.3.1

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.3.0'.freeze
+TINKER_VERSION = '0.3.1'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'be85494d426d4c5ff476075e18e43fd31ffb2e8a3a3fa9bdf84b67e035f291c7' # .gem
+  sha256 '33936ac7476f049cdb5aa99791bea130d0ddcff48cccc859fd11ea2ac6a778c1' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1201

Update tinker formula to install version 0.3.1

### Testing

Checkout this branch and remove existing installation:
```
git checkout jSRE_1201-update-homebrew-formula-for-re
brew remove tinker
```
Run the install:
```
brew install --build-from-source Formula/tinker.rb
brew test Formula/tinker.rb # Ensure test throws no error
```

Run sample Tinker commands to confirm that tinker works as expected:
```shell
tinker --version # Should return 0.3.1
LOG_LEVEL=trace tinker console
tinker tf imports --config infra/deploy-testing.yaml --json | jq
```
Remove this test version installed.