### PR TITLE
SRE_1212 updating session manger plugin to work for all macOS

### DIFF
--- a/Formula/session-manager-plugin.rb
+++ b/Formula/session-manager-plugin.rb
@@ -8,12 +8,12 @@ class SessionManagerPlugin < Formula
   homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
 
   on_macos do
-    sha256 'dad3eb15607c675d20ddc8a4b199c46d458b70ed6188afb7c83fb1a1d7a44911'
-    url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/session-manager-plugin.pkg",
+    sha256 'acec1d7dcddb81c6eb1bd29eb137609e9bb2421196f27b1aa3a800fc48277da2'
+    url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/sessionmanager-bundle.zip",
         verified: 's3.amazonaws.com/session-manager-downloads/'
   end
 
-  on_linux do
+  on_linux do 
     sha256 '12bcbec7d394275c2085d610fdbd53171c9083b3abf332d90baf3bcc3e730d2c'
     url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/ubuntu_64bit/session-manager-plugin.deb",
         verified: 's3.amazonaws.com/session-manager-downloads/'
@@ -46,8 +46,8 @@ class SessionManagerPlugin < Formula
     self.fail_if_already_installed
 
     on_macos do
-      system 'tar', 'xvf', 'session-manager-plugin.pkg'
-      system 'tar', 'xvf', 'Payload'
+      bin.install "bin/session-manager-plugin"
+      prefix.install %w[LICENSE VERSION]
     end
 
     on_linux do


### PR DESCRIPTION
Only changes MacOS:
Remove any existing versions so they don't interfere with testing:
```
brew remove tinker session-manager-plugin
brew update
```

Because of the SHA difference, download the session-manager-plugin from the formula reference first:
```
brew install --build-from-source Formula/session-manager-plugin.rb
```
Reinstall Tinker with the local formula
```
brew install --build-from-source Formula/tinker.rb
```

This will take several minutes. Confirm the installation is successful and that the proper versions are installed:
```
tinker --version 
> 0.3.1
```
```
/usr/local/bin/session-manager-plugin --version
> 1.2.295.0
```

After you are done testing, you can uninstall 
```
brew remove tinker session-manager-plugin
```