### PR TITLE
SRE_1213 adding cmake to dependencies

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -32,6 +32,9 @@ class Tinker < Formula
   depends_on "pkg-config" => :build
   depends_on "readline" => :build
   depends_on "zlib" => :build
+
+  # Build dependencies that will be used by Rugged
+  depends_on "cmake" => :build
   
   # Runtime dependencies that will be used by Tinker.
   depends_on "awscli" => "2"


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1213

Currently users are not able to download Tinker without running `brew install cmake` first. This update adds `cmake`  a dependency in the homebrew formula so users will not have to run `brew install cmake` before downloading Tinker.

## Reproduce

Uninstall Tinker
```
brew uninstall tinker
```
Uninstall cmake if you have it downloaded already
```
brew uninstall cmake
```
Install Tinker (not from this branch)
```
brew install snapsheet/core/tinker
```
You should see the following error:
```
Last 15 lines from /Users/deena.tenzer/Library/Logs/Homebrew/tinker/02.gem:
	--srcdir=.
	--curdir
	--ruby=/usr/local/Cellar/tinker/0.3.1/.rvm/rubies/ruby-2.7.1/bin/$(RUBY_BASE_NAME)
	--with-sha1dc
	--without-sha1dc
	--use-system-libraries

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/Cellar/tinker/0.3.1/.rvm/gems/ruby-2.7.1/extensions/x86_64-darwin-21/2.7.0/rugged-1.1.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/Cellar/tinker/0.3.1/.rvm/gems/ruby-2.7.1/gems/rugged-1.1.1 for inspection.
Results logged to /usr/local/Cellar/tinker/0.3.1/.rvm/gems/ruby-2.7.1/extensions/x86_64-darwin-21/2.7.0/rugged-1.1.1/gem_make.out

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/snapsheet/homebrew-core/issues
```

## Test Fix
Checkout this branch.
```
git checkout jSRE_1213-install-error-with-rugged
```

Uninstall Tinker again
```
brew uninstall tinker
```
Install Tinker from source. Tinker should download with no issues
```
brew install --build-from-source Formula/tinker.rb
```
You should see `cmake` being downloaded in the CLI during the Tinker download. i.e. mine shows:
```
==> Downloading https://ghcr.io/v2/homebrew/core/cmake/manifests/3.23.1
Already downloaded: /Users/deena.tenzer/Library/Caches/Homebrew/downloads/1d8aa3755eca27e1d8508c83db5a286ec8246706eb278691b67e139a9ea78423--cmake-3.23.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/cmake/blobs/sha256:67dedaec2350dcd6535d442cfe152589c743141cf72a078fde582f0e15be1b48
Already downloaded: /Users/deena.tenzer/Library/Caches/Homebrew/downloads/66023b0f3e86422d04139fd26d8364022e86e26baa3233cac701b0c250bdb25e--cmake--3.23.1.monterey.bottle.tar.gz
```