### PR TITLE
SRE-1244: Update tinker to 0.4.1

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '25ce690cc457d0000ede92a13ef68d8d3d32ca3aa713c0404079785cab9b5788' # .gem
+  sha256 'aa26bcc4d76bf169811ca8331a87d642bb11915829a1b5732826571160048f89' # .gem
   license 'MIT'
   version TINKER_VERSION
 

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.4.0'.freeze
+TINKER_VERSION = '0.4.1'.freeze
 
 class Tinker < Formula
   include RubyManager


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1244

Update the Tinker version number and checksum to version 0.4.1

### Testing
Checkout this branch.
```shell
git remote update --prune && git checkout jSRE_1244-update-homebrew-to-install-tin
```

Remove tinker from your local.
```
brew remove tinker
```

Run the installer on macOS
```
brew install --build-from-source Formula/tinker.rb
```

Confirm the version was installed
```
 tinker --version
```
0.4.1

Uninstall this version and reinstall the current version of Tinker:
```shell
brew remove tinker
brew install snapsheet/core/tinker
tinker --version
```
0.4.0
