### PR TITLE
SRE-1263: Update Tinker to 0.5.0

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.4.1'.freeze
+TINKER_VERSION = '0.5.0'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'aa26bcc4d76bf169811ca8331a87d642bb11915829a1b5732826571160048f89' # .gem
+  sha256 '67d094a85e310f1db51a418a39b407d0829eee89166c6ba3410c94356c4cd068' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1263

Update the Tinker version number and checksum to version 0.5.0

### Testing
Checkout this branch.
```shell
git remote update --prune && git checkout jSRE_1263-update-tinker-formula-for-vers
```

Remove tinker from your local.
```
brew remove tinker
```

Run the installer on macOS
```
brew install --build-from-source Formula/tinker.rb
```

Confirm the version was installed
```
 tinker --version
```
0.5.0

Uninstall this version and reinstall the current version of Tinker:
```shell
brew remove tinker
brew install snapsheet/core/tinker
tinker --version
```
0.4.1
