### PR TITLE
SRE-1371 Update Tinker Formula for Version 0.5.1

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.5.0'.freeze
+TINKER_VERSION = '0.5.1'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '67d094a85e310f1db51a418a39b407d0829eee89166c6ba3410c94356c4cd068' # .gem
+  sha256 '9d14837499abef7ce53804d8c382c029ae15338092d50c6ecc91575a8278fb97' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1371

This releases Tinker version 0.5.1

### Testing
Remove tinker on your local.
```
brew remove tinker
```

Checkout this branch and install Tinker using the script.
```
git checkout jSRE_1371-update-tinker-formula-for-vers
brew install --build-from-source Formula/tinker.rb
```

Verify the correct tinker version.
```
tinker --version
0.5.1
```

Verify that the help messages for the `tinker tf` subcommands (like `tinker tf help imports`) looks as expected.
```
Usage:
  tinker tf imports

Options:
      --config=CONFIG
      [--environment=ENVIRONMENT]
      [--json], [--no-json]
      [--profile=PROFILE]
      [--project=PROJECT]
      [--region=REGION]
  -v, [--verbose], [--no-verbose]

Render a list of key-value pairs representing already existing resources.
```

Verify that `tinker tf help` looks as expected.
```
Commands:
  tinker tf config          # Generate a Terraform-compatible JSON string.
  tinker tf default         # Given a YAML environment config, run Terraform commands.
  tinker tf help [COMMAND]  # Describe subcommands or one specific subcommand
  tinker tf imports         # Render a list of key-value pairs representing already existing resources.

Options:
  -v, [--verbose], [--no-verbose]
```

Verify that `tinker help tf` looks as expected.
```
Commands:
  tinker tf config          # Generate a Terraform-compatible JSON string.
  tinker tf default         # Given a YAML environment config, run Terraform commands.
  tinker tf help [COMMAND]  # Describe subcommands or one specific subcommand
  tinker tf imports         # Render a list of key-value pairs representing already existing resources.

Options:
  -v, [--verbose], [--no-verbose]
```

Remove the testing version and reinstall the released version.
```
brew remove tinker
brew install snapsheet/core/tinker
```