### PR TITLE
SRE_1392 updating version and sha to 0.5.2

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.5.1'.freeze
+TINKER_VERSION = '0.5.2'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '9d14837499abef7ce53804d8c382c029ae15338092d50c6ecc91575a8278fb97' # .gem
+  sha256 'd01814c4e34fdc14d30ed0a0e699819b58815ea1df1fbfa2aa81b9deb2a62f83' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1392


### Testing
Remove tinker on your local.
```
brew remove tinker
```

Checkout this branch and install Tinker using the script.
```
git checkout jSRE_1392-update-tinker-formula-for-vers
brew install --build-from-source Formula/tinker.rb
```

Verify the correct tinker version.
```
tinker --version
0.5.2
```

Remove the testing version and reinstall the released version.
```
brew remove tinker
brew install snapsheet/core/tinker
```