### PR TITLE
SRE-1441 Update Tinker Homebrew Formula to 0.5.3

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.5.2'.freeze
+TINKER_VERSION = '0.5.3'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'd01814c4e34fdc14d30ed0a0e699819b58815ea1df1fbfa2aa81b9deb2a62f83' # .gem
+  sha256 'e294c29b7232329aa94b13607d8ad62ac9e31e54c410f6eb11255f3cb4fd8508' # .gem
   license 'MIT'
   version TINKER_VERSION
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ brew test <formula>
 ```
 
 ## Development
-To install from a formula in a local ruby script, run installation with `--build-from-source` followed by the path to the ruby script.
+To install from a formula in a local ruby script, run installation with `--formula` and `--build-from-source` followed by the path to the ruby script.
 ```
-brew install --build-from-source Formula/<formula>.rb
+brew install --formula --build-from-source Formula/<formula>.rb
 ```
 
-Adding the `--debug` flag will give you additional debug options if the installation fails.
+Adding the `--debug` flag will give you additional debug options if the installation fails. For more information, see the [online man page](https://docs.brew.sh/Manpage) or run `brew install help`.
 
 ## Testing With Linux
 This project uses [docker compose](https://docs.docker.com/compose/) to create a development environment you can use for testing installations on Linux.


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1441

**NOTE**: Recently Homebrew updated to [version 3.6.0](https://brew.sh/2022/09/07/homebrew-3.6.0/). Since this upgrade I ran into issues when installing session-manager-plugin as a dependency of a locally-run formula. I've confirmed that the existing dependency on the remote formula (Github/here) still works. You will also confirm this as the last step.

### Testing
Make sure homebrew is up to date:
```shell
brew update && brew upgrade
```

Remove your local version of tinker and session-manager-plugin:
```shell
brew remove tinker
brew remove session-manager-plugin
```

You must also explicitly remove the snapsheet/core tap:
```shell
brew untap snapsheet/core
```

Check out this branch:
```shell
git checkout jSRE_1441-update-tinker-homebrew-formula
```

Open `Formula/tinker.rb` in a text editor and comment-out this line:
```ruby
#depends_on "snapsheet/core/session-manager-plugin" => "1.2.295"
```

Run brew install with the formula. This will take several minutes.
```shell
brew install --formula --build-from-source Formula/tinker.rb
```

Confirm that you have the latest version of Tinker:
```shell
tinker --version # (should be 0.5.3)
```

Test and validate. When you are done, remove this version and reinstall the tap-version of tinker:
```shell
brew remove tinker
brew install snapsheet/core/tinker
```