### PR TITLE
SRE-1451 Update Tinker Homebrew Formula to 0.5.4

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.5.3'.freeze
+TINKER_VERSION = '0.5.4'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'e294c29b7232329aa94b13607d8ad62ac9e31e54c410f6eb11255f3cb4fd8508' # .gem
+  sha256 'e2cc05f25f095ffb5da4d90671e33d6a0fe6d47266b0dd43ed74a3e90f91732e' # .gem
   license 'MIT'
   version TINKER_VERSION
 

--- a/lib/ruby_manager.rb
+++ b/lib/ruby_manager.rb
@@ -118,7 +118,7 @@ module RubyManager
     ) do
       system(
         "#{rvm_path}/bin/rvm",
-        '--autolibs=read-fail',
+        '--autolibs=disabled',
         '--with-gcc=gcc',
         '--verbose', '--debug',
         'install', ruby_version


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1451

Publish Tinker version 0.5.4

### Testing
Make sure homebrew is up to date:
```shell
brew update && brew upgrade
```

Remove your local version of tinker and session-manager-plugin:
```shell
brew remove tinker
brew remove session-manager-plugin
```

You must also explicitly remove the snapsheet/core tap:
```shell
brew untap snapsheet/core
```

Check out this branch:
```shell
git checkout jSRE_1451-update-tinker-homebrew-formula
```

Open `Formula/tinker.rb` in a text editor and comment-out this line:
```ruby
#depends_on "snapsheet/core/session-manager-plugin" => "1.2.295"
```

Run brew install with the formula. This will take several minutes.
```shell
brew install --formula --build-from-source Formula/tinker.rb
```

Confirm that you have the latest version of Tinker:
```shell
tinker --version # (should be 0.5.4)
```

Test and validate. When you are done, remove this version and reinstall the tap-version of tinker:
```shell
brew remove tinker
brew install snapsheet/core/tinker
```