### PR TITLE
SRE-1684 - Release Tinker 0.5.5

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.5.4'.freeze
+TINKER_VERSION = '0.5.5'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'e2cc05f25f095ffb5da4d90671e33d6a0fe6d47266b0dd43ed74a3e90f91732e' # .gem
+  sha256 '300582c01b077b994e9d201cfaa3eb8bec38aef5d7702f9c22eeddddff27688b' # .gem
   license 'MIT'
   version TINKER_VERSION
 

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -38,7 +38,6 @@ class Tinker < Formula
   
   # Runtime dependencies that will be used by Tinker.
   depends_on "awscli" => "2"
-  depends_on "snapsheet/core/session-manager-plugin" => "1.2.295"
 
   # Get the system home directory for the user installing Tinker. Attempting to find the home via
   # +path = `echo $HOME`+ will return the temporary path used while running this formula (same as

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ This is a Homebrew tap for useful formulae used by engineers at Snapsheet.
 * [Explanation of how Homebrew works](https://www.quora.com/How-does-Homebrew-work-internally?share=1)
 
 ## Installing Formulae via Homebrew
-Packages installed by these formulae require an environment variable with the GitHub token to be present with the name `HOMEBREW_GITHUB_API_TOKEN`. If you already use the Github API for your projects, this can be the same as your `GITHUB_TOKEN`. Add the following to your `.profile`/`.bashrc`/`.zshrc` file, where `xxxxx` represents your token. This will ensure that you are authenticated when installing a Snapsheet formula or updating a Snapsheet formula via Homebrew.
+Packages installed by these formulae require an environment variable with the GitHub token to be present with the name `HOMEBREW_GITHUB_API_TOKEN`. If you already use the Github API for your projects, this can be the same as your `GITHUB_TOKEN`.
+
+To generate a token that you can use using the GitHub CLI and SSO, run the `gh auth` command:
+```
+gh auth login --scopes read:packages
+```
+
+This will ask you to authenticate through your web browser to create a session in your CLI. Then you can use the `gh` command to get the token:
+```
+HOMEBREW_GITHUB_API_TOKEN=$(gh auth token)
+```
+
+Alternatively, you can generate a token via the GitHub web UI and add this to your `.profile`/`.bashrc`/`.zshrc` file, where `xxxxx` represents your token. This will ensure that you are authenticated when installing a Snapsheet formula or updating a Snapsheet formula via Homebrew.
 ```
 export HOMEBREW_GITHUB_API_TOKEN=xxxxx
 ```
@@ -20,6 +32,16 @@ brew test <formula>
 ```
 
 ## Development
+If your formula also lists dependencies from `snapsheet/core/...`, you may run into an issue where the logic in the dependency will start running over the logic defined locally. To fix this:
+1. Comment out the dependencies
+1. Uninstall them
+1. Untap the `snapsheet/core` tap
+1. Rerun
+```
+brew uninstall session-manager-plugin
+brew untap snapsheet/core
+```
+
 To install from a formula in a local ruby script, run installation with `--formula` and `--build-from-source` followed by the path to the ruby script.
 ```
 brew install --formula --build-from-source Formula/<formula>.rb


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1684

Bump release version and SHA.

# Testing

Ensure you have your Github token set as HOMEBREW_GITHUB_API_TOKEN in your CLI. If you are using the GitHub CLI with SSO, you can do it with the following commands:
```shell
gh auth login --scopes read:packages
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token)
```

Checkout this branch.

Run the following
```
brew install --formula --build-from-source Formula/tinker.rb
```

Verify that thinker installs version 0.5.5 correctly.
```
tinker --version
0.5.5
```

### Known Issue
When installing the `snapsheet/core/session-manager-plugin` dependency listed in the local version of the script, brew was raising an unusual error `Error: can't modify frozen class`. Since we do not yet use this as a dependency, I've removed it to unblock the testing and release of updated versions.