### PR TITLE
SRE_1771 updating Tinker version to 0.6.0

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.5.6'.freeze
+TINKER_VERSION = '0.6.0'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '09ce967021c5409b266d9c8b75ccad1fccf7644933378482ebb5c1abcbb10b1c' # .gem
+  sha256 'd92f39175cc2bce619d5b2425af4fb15129920d89b03ec2329e542c1710d0727' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1771

Bump release version and SHA.

# Testing

Ensure you have your Github token set as HOMEBREW_GITHUB_API_TOKEN in your CLI. If you are using the GitHub CLI with SSO, you can do it with the following commands:
```shell
gh auth login --scopes read:packages
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token)
```

Checkout this branch.
Remove the current Tinker first:
```
brew remove snapsheet/core/tinker
brew untap snapsheet/core
```

Then run the following
```
brew install --formula --build-from-source Formula/tinker.rb
```

Verify that thinker installs version 0.5.6 correctly.
```
tinker --version
0.6.0
```