### PR TITLE
SRE_1780 updating tinker version, sha, and new homebrew fetch

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.6.1'.freeze
+TINKER_VERSION = '0.7.0'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '8e3ff6a846aebc417b2dfb96b58c12d4540dc7428764977e15e89af9d0f38e2d' # .gem
+  sha256 '7f0a5e60035eea142ce54e1a384c6531d551105696774766ef826e223b4c456a' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1780
Bump release version and SHA.

# Testing

Ensure you have your Github token set as HOMEBREW_GITHUB_API_TOKEN in your CLI. If you are using the GitHub CLI with SSO, you can do it with the following commands:
```shell
gh auth login --scopes read:packages
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token)
```

Checkout this branch.
Remove the current Tinker first:
```
brew remove snapsheet/core/tinker
brew untap snapsheet/core
```

Then run the following
```
brew install --formula --build-from-source Formula/tinker.rb
```

Verify that thinker installs version 0.7.0 correctly. There is a known bug here so you will most likely see an error similar to this instead of the version:
```
tinker --version
/opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml/parser.rb:96:in `<class:Parser>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml/parser.rb:7:in `<module:Xml>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml/parser.rb:5:in `<module:Aws>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml/parser.rb:3:in `<top (required)>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml.rb:8:in `require_relative'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core/xml.rb:8:in `<top (required)>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core.rb:77:in `require_relative'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/aws-sdk-core-3.142.0/lib/aws-sdk-core.rb:77:in `<top (required)>'
	from <internal:/opt/homebrew/Cellar/tinker/0.7.0/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/opt/homebrew/Cellar/tinker/0.7.0/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/tinker-0.7.0/lib/tinker.rb:4:in `<top (required)>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/tinker-0.7.0/config/bootstrap.rb:14:in `require_relative'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/tinker-0.7.0/config/bootstrap.rb:14:in `<top (required)>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/tinker-0.7.0/bin/tinker:2:in `require_relative'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/gems/tinker-0.7.0/bin/tinker:2:in `<top (required)>'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/bin/tinker:25:in `load'
	from /opt/homebrew/Cellar/tinker/0.7.0/.rvm/gems/ruby-3.2.2/bin/tinker:25:in `<top (required)>'
	from /opt/homebrew/bin/tinker:11:in `load'
	from /opt/homebrew/bin/tinker:11:in `<main>'
```