### PR TITLE
SRE-1787 updating params

### DIFF
--- a/lib/ruby_gems_download_strategy.rb
+++ b/lib/ruby_gems_download_strategy.rb
@@ -48,7 +48,7 @@ class RubyGemsDownloadStrategy < AbstractDownloadStrategy
     [ENV['SHELL'], '--login', '-c', command_string]
   end
 
-  def fetch
+  def fetch(quiet: nil, verify_download_integrity: true, timeout: nil)
     ohai("Fetching #{name} gem from GitHub packages.")
     setup_debug_tools if Context.current.debug?
 


### PR DESCRIPTION
Fixing Homebrew breaking change:

## Test
Check out this branch. 
```
brew remove tinker && brew untap snapsheet/core

HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb

tinker --version
```

OR Update locally cached file instead of using this PR:
```
brew remove tinker && brew untap snapsheet/core

HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install snapsheet/core/tinker
# (will error out)

open /opt/homebrew/Library/Taps/snapsheet/homebrew-core/lib/ruby_gems_download_strategy.rb
# (edit `def fetch` to add all the parameters)
# def fetch(quiet: nil, verify_download_integrity: true, timeout: nil)

HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install snapsheet/core/tinker
```

Confirm tinker version 
```
 ✔tinker --version
> 0.6.1
```

## Known Issue
If you see the following error when running `tinker --version`
```
 ✔ tinker --version
/Users/deena.tenzer/.rvm/rubies/ruby-3.2.2/lib/ruby/site_ruby/3.2.0/rubygems.rb:263:in `find_spec_for_exe': can't find gem tinker (>= 0.a) with executable tinker (Gem::GemNotFoundException)
	from /Users/deena.tenzer/.rvm/rubies/ruby-3.2.2/lib/ruby/site_ruby/3.2.0/rubygems.rb:282:in `activate_bin_path'
	from /Users/deena.tenzer/.rvm/gems/ruby-3.2.2/bin/tinker:25:in `<main>'
	from /Users/deena.tenzer/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `eval'
	from /Users/deena.tenzer/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `<main>'
```
then run the following:
```
rvm use ruby-2.7.6
```