### PR TITLE
J sre 1782 broken gem from ruby 3 upgrade

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.7.0'.freeze
+TINKER_VERSION = '0.7.test'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '7f0a5e60035eea142ce54e1a384c6531d551105696774766ef826e223b4c456a' # .gem
+  sha256 '3b28135b605f7f5bb49bd916cc5931cf702de07a963ed31b67b015c01e1243ff' # .gem
   license 'MIT'
   version TINKER_VERSION
 

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.6.1'.freeze
+TINKER_VERSION = '0.7.0'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '8e3ff6a846aebc417b2dfb96b58c12d4540dc7428764977e15e89af9d0f38e2d' # .gem
+  sha256 '7f0a5e60035eea142ce54e1a384c6531d551105696774766ef826e223b4c456a' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
 Checkout this PR and run the following
```
brew remove snapsheet/core/tinker
brew untap snapsheet/core

```
Be sure you are inside the homebrew-core directory with this checked out draft PR and run
```
brew install --formula --build-from-source Formula/tinker.rb
```

When you run `tinker --version` after the install succeeds, you should see `0.7.test` printed with no errors.