### PR TITLE
SRE_1820 Updating tinker version 0.7.2 and SHA

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '0.7.1'.freeze
+TINKER_VERSION = '0.7.2'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'c507eec2649162468a3e9f4b526044985cefb9d26a4749598185b70c73dab28c' # .gem
+  sha256 '7e0178d4e78a8e873e9785f45a9e12922ce4095af20b67ac610404e15d01488a' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1820

## Test
Check out this branch and run the following
```
brew remove tinker && brew untap snapsheet/core
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm tinker version 
```
 ✔tinker --version
> 0.7.2
```