### PR TITLE
Tinker Patch 1.0.1

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -8,7 +8,7 @@ require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
 
-TINKER_VERSION = '1.0.0'.freeze
+TINKER_VERSION = '1.0.1'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -17,7 +17,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '8d2c1755eeb8dc2d05f1eec9bc53c08e0862076ff66a39d6c495519a18b85e20' # .gem
+  sha256 '18a9a4c47545a00060a586e2354c4a2f03836b9c7bf10a540787be3d2bf7bf2f' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
This updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.0.1
```

Run tinker commands to validate expected behavior.

```shell
❯ tinker run -p guidelines -e production -r us-east-1 ls -lah
⠇ Task[fb534c75d4cb459e897fde9a119ed699](RUNNING) ExecuteCommandAgent(RUNNING) 

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.
# ...
```

Uninstall this version and reinstall the official version:
```shell
brew uninstall tinker
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install snapsheet/core/tinker
```