### PR TITLE
SRE-2118-homebrew-tinker-download-failing

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -7,7 +7,6 @@ require_relative '../lib/ruby_manager'
 require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
-
 TINKER_VERSION = '1.0.1'.freeze
 
 class Tinker < Formula
@@ -59,7 +58,7 @@ class Tinker < Formula
   #
   # @return [Object] Reference to metadata object loaded from a gem.
   def metadata
-    @metadata ||= YAML.load(`tar -xOf #{tinker_gem_path} metadata.gz | gzip -dc`)
+    @metadata ||= YAML.load(`tar -xOf #{tinker_gem_path} metadata.gz | gzip -dc`, permitted_classes: [Gem::Specification, Gem::Version, Gem::Dependency, Gem::Requirement, Gem::Platform, Time, Symbol])
   end
 
   # Find the path of the gem that will be installed by this formula.
@@ -117,11 +116,10 @@ class Tinker < Formula
   end
 
   def install
+    
     setup_debug_tools if Context.current.debug?
-
     bin.rmtree if bin.exist?
     bin.mkpath
-
     log_path = if OS.mac?
       "#{user_home}/Library/Logs/Homebrew/tinker"
     elsif OS.linux?

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -7,6 +7,7 @@ require_relative '../lib/ruby_manager'
 require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
+require 'rubygems/package'
 
 TINKER_VERSION = '1.0.1'.freeze
 
@@ -59,7 +60,7 @@ class Tinker < Formula
   #
   # @return [Object] Reference to metadata object loaded from a gem.
   def metadata
-    @metadata ||= YAML.load(`tar -xOf #{tinker_gem_path} metadata.gz | gzip -dc`, permitted_classes: [Gem::Specification, Gem::Version, Gem::Dependency, Gem::Requirement, Time, Symbol])
+    @metadata ||= Gem::Package.new(tinker_gem_path).spec
   end
 
   # Find the path of the gem that will be installed by this formula.

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -7,6 +7,7 @@ require_relative '../lib/ruby_manager'
 require_relative '../lib/debug_tools'
 require 'net/http'
 require 'uri'
+
 TINKER_VERSION = '1.0.1'.freeze
 
 class Tinker < Formula
@@ -115,11 +116,12 @@ class Tinker < Formula
     end
   end
 
-  def install
-    
+  def install    
     setup_debug_tools if Context.current.debug?
+    
     bin.rmtree if bin.exist?
     bin.mkpath
+
     log_path = if OS.mac?
       "#{user_home}/Library/Logs/Homebrew/tinker"
     elsif OS.linux?

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -59,7 +59,7 @@ class Tinker < Formula
   #
   # @return [Object] Reference to metadata object loaded from a gem.
   def metadata
-    @metadata ||= YAML.load(`tar -xOf #{tinker_gem_path} metadata.gz | gzip -dc`, permitted_classes: [Gem::Specification, Gem::Version, Gem::Dependency, Gem::Requirement, Gem::Platform, Time, Symbol])
+    @metadata ||= YAML.load(`tar -xOf #{tinker_gem_path} metadata.gz | gzip -dc`, permitted_classes: [Gem::Specification, Gem::Version, Gem::Dependency, Gem::Requirement, Time, Symbol])
   end
 
   # Find the path of the gem that will be installed by this formula.

--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -116,9 +116,9 @@ class Tinker < Formula
     end
   end
 
-  def install    
+  def install
     setup_debug_tools if Context.current.debug?
-    
+
     bin.rmtree if bin.exist?
     bin.mkpath
 


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-2118
## What
Homebrew upgraded to ruby 3 and we need to update our formula so that it works with the new version.

## Why
Jacob notice the following an error while updating tinker. 
```
jake@KQVPM7HPQT ~ % brew install snapsheet/core/tinker  
==> Fetching snapsheet/core/tinker
==> Fetching tinker gem from GitHub packages.
Downloaded tinker-1.0.1
==> Installing tinker from snapsheet/core
Error: An exception occurred within a child process:
  Psych::DisallowedClass: Tried to load unspecified class: Gem::Specification
jake@KQVPM7HPQT ~ % 
```

## How
Load the metadata using [Gem::Package library](https://docs.ruby-lang.org/en/master/Gem/Package.html). 


## Testing
Uninstall tinker using 
```
brew uninstall session-manager-plugin
brew untap snapsheet/core
brew uninstall tinker
```

checkout main and run 
```
brew install --formula --build-from-source Formula/tinker.rb
```

You should see an error.

```
Error: An exception occurred within a child process:
  Psych::DisallowedClass: Tried to load unspecified class: Gem::Specification
```

Checkout this branch and run 
```
brew reinstall --formula --build-from-source Formula/tinker.rb
```

You should see that you do not run into the error anymore.