### PR TITLE
Updating tinker version to 1.0.2

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.0.1'.freeze
+TINKER_VERSION = '1.0.2'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '18a9a4c47545a00060a586e2354c4a2f03836b9c7bf10a540787be3d2bf7bf2f' # .gem
+  sha256 '85fa3a2289bfac1801696c5dfa58316b4405b1197e1d5c2acc0085387a4e8c3f' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
This updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.0.2
```

Run tinker commands to validate expected behavior.

```shell
❯ sail tinker run -p snapsheet-tx --environment uat --region us-east-1 rails c
⠇ Task[fb534c75d4cb459e897fde9a119ed699](RUNNING) ExecuteCommandAgent(RUNNING) 

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.
# ...
```

Uninstall this version and reinstall the official version:
```shell
brew uninstall tinker
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install snapsheet/core/tinker
```