### PR TITLE
Tinker to 1.1.0

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.0.2'.freeze
+TINKER_VERSION = '1.1.0'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '85fa3a2289bfac1801696c5dfa58316b4405b1197e1d5c2acc0085387a4e8c3f' # .gem
+  sha256 'b20c52ae2a18e10868c8988c922cfd1da3f775cb7a383784fa87baf6ae9c132b' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
This updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.1.0
```

Run tinker keys list command to confirm tinker 1.1.0 is downloaded properly.

```shell
❯ tinker keys list -p snapsheet-tx -e qa3 
```

Uninstall this version and reinstall the official version:
```shell
brew uninstall tinker
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install snapsheet/core/tinker
```