### PR TITLE
updating to tinker 1.3.1

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.3.0'.freeze
+TINKER_VERSION = '1.3.1'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '29a9e59e325e4853466f58eb6df209940ca552b9ffa36178d2db437da52972cd' # .gem
+  sha256 '2252e20841e1ed675a81660074a058d9aaf408b51e37c2b77db4b4680c746b52' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
This updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.3.1
```

Run tinker commands to validate expected behavior.

```shell
❯ tinker keys set -p api-gateway -e qa1 TEST_KEY=test_val
```
Confirm secrets are set and [resources](https://us-east-2.console.aws.amazon.com/ecs/v2/clusters/api-gateway-qa1/services?region=us-east-2) are updated properly.

Remove secret:
```shell
❯ tinker keys remove -p api-gateway -e qa1 TEST_KEY
```

Uninstall this version and reinstall the official version:
```shell
brew uninstall tinker
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install snapsheet/core/tinker
```