### PR TITLE
Updating tinker version and SHA

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.3.2'.freeze
+TINKER_VERSION = '1.3.4'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '1dd5e07c1012f7bbcc690e395524107b3aac3ab040b844aedb3b5f017eae6204' # .gem
+  sha256 'a2df8ba3ff4c0c8e8d209a447806057f6575ea93e451b2b11e57ab66e7dc8faa' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
This updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.3.4
```

Run tinker session command to validate expected behavior.

```shell
❯ tinker session list -p vice-backend -e uat-1 -r us-east-1
```
Confirm this returns either a table with the session information or `No remote session tasks currently running.`


## Possible Error
I saw an error when downloading this new version
```
Error: /opt/homebrew/bin/gh is too old, you must upgrade it to continue
```

This is unrelated to this change, and related to homebrew and `gh`. I fixed this by running the following
```
brew uninstall github/gh/gh
brew install gh
brew upgrade

HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
``` 
