### PR TITLE
Updating tinker version to 1.3.5

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.3.4'.freeze
+TINKER_VERSION = '1.3.5'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 'a2df8ba3ff4c0c8e8d209a447806057f6575ea93e451b2b11e57ab66e7dc8faa' # .gem
+  sha256 '7fd426a7ccd16fdd418e6e7a6c7217ff08e3ba2ccec02e7327da6a340cbac724' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
This updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.3.5
```

Run tinker session command to validate expected behavior.

```shell
❯ tinker deploy -e qa5 -r us-east-2 -p vice-backend --tag 9b2e-qa5__e0d5fa8bb2__2024-07-11_070602
```
Confirm this runs with no errors or timeouts. This confirms that the task definitions are being created properly with and without tags. This also confirms timeouts do not occur.

Run a build. Navigate into the guidelines directory:
```shell
cd guidelines/
rm -rf cdktf/cdktf.out
rm -rf cdktf/node_modules
tinker build -p guidelines -e qa1 -t qa1-test -r us-east-2 --no-push --platform linux/amd64 .
```

