### PR TITLE
updating to tinker 1.3.6

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.3.5'.freeze
+TINKER_VERSION = '1.3.6'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '7fd426a7ccd16fdd418e6e7a6c7217ff08e3ba2ccec02e7327da6a340cbac724' # .gem
+  sha256 'fcf118d83ddee74691273cc386ba8ebde819f48a3974084288a77c617d94680e' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.3.6
```

Run a deployment to QA6
``` shell
tinker deploy -e qa6 -r us-east-2 -p vice-backend --tag 9b2e-qa6__9f4c625e93__2024-08-15_223501
```
Once the deployment is complete, run the following and confirm there are no errors running the session
```shell
tinker run -e qa6 -p vice-backend -r us-east-2 bash
```
