### PR TITLE
Updating to tinker 1.5.1

### DIFF
--- a/Formula/tinker.rb
+++ b/Formula/tinker.rb
@@ -9,7 +9,7 @@ require 'net/http'
 require 'uri'
 require 'rubygems/package'
 
-TINKER_VERSION = '1.4.0'.freeze
+TINKER_VERSION = '1.5.1'.freeze
 
 class Tinker < Formula
   include RubyManager
@@ -18,7 +18,7 @@ class Tinker < Formula
   desc 'Install the Tinker toolset.'
   homepage 'https://github.com/bodyshopbidsdotcom/tinker'
   url('tinker', using: RubyGemsDownloadStrategy)
-  sha256 '808d2169e2f4241178a2bacd06d01bb9adcf8f89362c28ef98a2642148deeadd' # .gem
+  sha256 '344c5089504730a7e5e1d34e8747c7afdd9faffd8b3cec997e2367cd39491a47' # .gem
   license 'MIT'
   version TINKER_VERSION
 


### PR DESCRIPTION
Updates the version number and SHA for the next release of Tinker.

### Testing

Remove your current installation of tinker.
```shell
brew uninstall tinker
```

Checkout this branch and install tinker via the provided formula.
```shell
HOMEBREW_GITHUB_API_TOKEN=$(gh auth token) brew install --formula --build-from-source Formula/tinker.rb
```

Confirm it installed the correct version.
```shell
❯ tinker --version
1.5.1
```

